### PR TITLE
fix: Align Go version in workflow with go.work

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,23 @@
+name: Go Tests (sourcetool)
+
+on:
+  pull_request:
+
+jobs:
+  test:
+    permissions:
+      contents: read
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.23.5'
+
+      - name: Run Go tests
+        run: go test ./sourcetool/...


### PR DESCRIPTION
Updates the GitHub Action workflow for Go unit tests to use Go version 1.23.5, as specified in the `go.work` file.

This ensures consistency between the CI environment and the project's defined Go version.